### PR TITLE
add type@express and modify dotenv

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@types/express": "^5.0.0",
+    "dotenv": "^16.4.5",
     "cors": "^2.8.5",
     "express": "^4.21.1",
     "knex": "^3.1.0",
@@ -21,10 +23,8 @@
     "ts-node": "^10.9.2"
   },
   "devDependencies": {
-    "@types/express": "^5.0.0",
     "chai": "^4.2.0",
     "chai-http": "^4.3.0",
-    "dotenv": "^16.4.5",
     "nodemon": "^3.1.7"
   }
 }


### PR DESCRIPTION
type@expressはtypescript用  
dotenvはデプロイ先でも参照できる必要があるためdevDependencies→dependenciesに移動
